### PR TITLE
🤠 use bit shifting instead & solc `0.8.17`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ forge install JoshuaTrujillo15/ez-bitmap
 The type can be used by importing from this library as follows.
 
 ```solidity
+pragma solidity ^0.8.13;
+
 import {Bitmap} from "ez-bitmap/src/Bitmap.sol";
 
 contract MyCon {

--- a/src/Bitmap.sol
+++ b/src/Bitmap.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.16;
+pragma solidity ^0.8.17;
 
 // Used for masking.
-uint256 constant MASK = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+uint256 constant MASK = (1 << 256) - 1;
 
 // Alias to uint256. Stored on the stack.
 type Bitmap is uint256;


### PR DESCRIPTION
I was quickly screening through your code and thought I would change the following:
- add `^0.8.13` for the example code snippet since below it doesn't work;
- updated the solc version of `Bitmap.sol` to the latest version. The main reason is that `0.8.16` had a (Yul) optimizer bug and most people using inline-assembly Yul also love bitmaps. Therefore, I want to discourage the usage of that version :)
- use bit shifting for the mask (I don't know, I just find it cleaner like that lol)

Cool repo btw!